### PR TITLE
Use Oj correctly as the JSON engine

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -33,13 +33,13 @@ module SerializationBenchmark
 
     b.report('AMS Ultra Simple') do
       sample_size.times do
-        TeamSerializer.new(team).to_json
+        JsonEncoder.dump(TeamSerializer.new(team).as_json)
       end
     end
 
     b.report('Presenters Ultra Simple') do
       sample_size.times do
-        TeamPresenter.new(team).to_json
+        JsonEncoder.dump(TeamPresenter.new(team).as_json)
       end
     end
 
@@ -53,13 +53,13 @@ module SerializationBenchmark
 
     b.report('AMS Simple') do
       sample_size.times do
-        EventSummarySerializer.new(event).to_json
+        JsonEncoder.dump(EventSummarySerializer.new(event).as_json)
       end
     end
 
     b.report('Presenters Simple') do
       sample_size.times do
-        EventSummaryPresenter.new(event).to_json
+        JsonEncoder.dump(EventSummaryPresenter.new(event).as_json)
       end
     end
 
@@ -73,13 +73,13 @@ module SerializationBenchmark
 
     b.report('AMS Complex') do
       sample_size.times do
-        Basketball::EventSerializer.new(event).to_json
+        JsonEncoder.dump(Basketball::EventSerializer.new(event).as_json)
       end
     end
 
     b.report('Presenters Complex') do
       sample_size.times do
-        Basketball::EventPresenter.new(event).to_json
+        JsonEncoder.dump(Basketball::EventPresenter.new(event).as_json)
       end
     end
   end
@@ -98,13 +98,18 @@ module SerializationBenchmark
 
     b.report('AMS Ultra Simple: Collection') do
       sample_size.times do
-        ActiveModel::ArraySerializer.new(team_collection, each_serializer: TeamSerializer).to_json
+        result = ActiveModel::ArraySerializer.
+          new(team_collection, each_serializer: TeamSerializer).
+          as_json
+
+        JsonEncoder.dump(result)
       end
     end
 
     b.report('Presenters Ultra Simple: Collection') do
       sample_size.times do
-        team_collection.map { |team| TeamPresenter.new(team).as_json }.to_json
+        result = team_collection.map { |team| TeamPresenter.new(team).as_json }
+        JsonEncoder.dump(result)
       end
     end
 
@@ -118,13 +123,18 @@ module SerializationBenchmark
 
     b.report('AMS Simple: Collection') do
       sample_size.times do
-        ActiveModel::ArraySerializer.new(event_collection, each_serializer: EventSummarySerializer).to_json
+        result = ActiveModel::ArraySerializer.
+          new(event_collection, each_serializer: EventSummarySerializer).
+          as_json
+
+        JsonEncoder.dump(result)
       end
     end
 
     b.report('Presenters Simple: Collection') do
       sample_size.times do
-        event_collection.map { |event| EventSummaryPresenter.new(event).as_json }.to_json
+        result = event_collection.map { |event| EventSummaryPresenter.new(event).as_json }
+        JsonEncoder.dump(result)
       end
     end
 
@@ -138,13 +148,18 @@ module SerializationBenchmark
 
     b.report('AMS Complex: Collection') do
       sample_size.times do
-        ActiveModel::ArraySerializer.new(event_collection, each_serializer: Basketball::EventSerializer).to_json
+        result = ActiveModel::ArraySerializer.
+          new(event_collection, each_serializer: Basketball::EventSerializer).
+          as_json
+
+        JsonEncoder.dump(result)
       end
     end
 
     b.report('Presenters Complex: Collection') do
       sample_size.times do
-        event_collection.map { |event| Basketball::EventPresenter.new(event).as_json }.to_json
+        result = event_collection.map { |event| Basketball::EventPresenter.new(event).as_json }
+        JsonEncoder.dump(result)
       end
     end
   end

--- a/lib/json_encoder.rb
+++ b/lib/json_encoder.rb
@@ -1,0 +1,5 @@
+class JsonEncoder
+  def self.dump(hash_or_array)
+    Oj.dump(hash_or_array, mode: :compat)
+  end
+end

--- a/lib/json_serialization_benchmark.rb
+++ b/lib/json_serialization_benchmark.rb
@@ -1,6 +1,8 @@
 require File.join(File.dirname(__FILE__), '..', 'config', 'environment')
 
-require 'active_support/core_ext/object/json'
+require 'active_support/json/encoding'
+
+require 'json_encoder'
 
 require 'models/model'
 require 'models/box_score'

--- a/lib/rabl/init.rb
+++ b/lib/rabl/init.rb
@@ -1,4 +1,5 @@
 Rabl.configure do |config|
+  config.json_engine = JsonEncoder
   config.cache_sources = false
   config.include_json_root = false
   config.enable_json_callbacks = true


### PR DESCRIPTION
Though Oj was originally intended to be used (hence it was in the Gemfile), it was not being used by all of Rabl, AMS, and presenters.

In fact, it was only being used by Rabl as it is the engine Rabl uses by default. In othewords, the benchmark was unfair to AMS and presenters. With the Oj boost to AMS and presenters, the relative performance of Rabl gets even worse.

**NOTE**: I will update the blog post (http://techblog.thescore.com/benchmarking-json-generation-in-ruby) with up-to-date benchmark results once this gets merged into master.
